### PR TITLE
Fix/cma 140 front completed search UI

### DIFF
--- a/src/components/template/quest/completed-search/CompletedSearchTemplate.tsx
+++ b/src/components/template/quest/completed-search/CompletedSearchTemplate.tsx
@@ -26,6 +26,7 @@ interface CompletedSearchTemplateProps {
   onClickPrev: () => void;
   spotifyArtistData: SpotifyArtistProps[] | undefined;
   spotifyTrackData: TrackType[] | undefined;
+  spotifyArtistDetailTrackData: TrackType[] | undefined;
   commaUserData: CommaUserType[] | undefined;
 }
 
@@ -35,6 +36,7 @@ export const CompletedSearchTemplate = ({
   category,
   completedTextValue,
   spotifyArtistForDetailArtist,
+  spotifyArtistDetailTrackData,
   setSwiperRef,
   onClickRoundInput,
   onClickEraseButton,
@@ -93,7 +95,7 @@ export const CompletedSearchTemplate = ({
         <style.Slide>
           <ArtistDetailForm
             soptifyArtistData={spotifyArtistForDetailArtist}
-            spotifyTrackData={spotifyTrackData}
+            spotifyTrackData={spotifyArtistDetailTrackData}
             isLike={false}
           />
         </style.Slide>

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -41,6 +41,8 @@ export const useSearch = () => {
   const [spotifyArtistData, setSpotifyArtistData] =
     useState<SpotifyArtistProps[]>();
   const [spotifyTrackData, setSpotifyTrackData] = useState<TrackType[]>();
+  const [spotifyArtistDetailTrackData, setSpotifyArtistDetailTrackData] =
+    useState<TrackType[]>();
   const [commaUserData, setCommaUserData] = useState<CommaUserType[]>();
 
   const { mutate: mutateTrack } = useMutation(['Track'], getSpotifyTrack, {
@@ -55,6 +57,23 @@ export const useSearch = () => {
       }
     },
   });
+
+  const { mutate: mutateArtistDetailTrack } = useMutation(
+    ['ArtistDetailTrack'],
+    getSpotifyTrack,
+    {
+      onSuccess: (response) => {
+        if (response.result.data) {
+          if ('errors' in response.result.data) {
+            console.log('error:', response.result.data.errors);
+          } else if (response.result.data) {
+            const newTrackData = response.result.data;
+            setSpotifyArtistDetailTrackData(newTrackData);
+          }
+        }
+      },
+    },
+  );
 
   const { mutate: mutateArtist } = useMutation(['artist'], getSpotifyArtist, {
     onSuccess: (response) => {
@@ -112,10 +131,13 @@ export const useSearch = () => {
     searchHistory,
     spotifyArtistData,
     spotifyTrackData,
+    spotifyArtistDetailTrackData,
+    setSpotifyArtistDetailTrackData,
     commaUserData,
     mutateArtist,
     mutateTrack,
     mutateCommaUser,
     mutateSearchHistory,
+    mutateArtistDetailTrack,
   };
 };

--- a/src/pages/quest/completedSearch.tsx
+++ b/src/pages/quest/completedSearch.tsx
@@ -18,10 +18,13 @@ const CompletedSearch = () => {
   const {
     spotifyArtistData,
     spotifyTrackData,
+    spotifyArtistDetailTrackData,
+    setSpotifyArtistDetailTrackData,
     commaUserData,
     mutateArtist,
     mutateTrack,
     mutateCommaUser,
+    mutateArtistDetailTrack,
   } = useSearch();
   const { mutateSetTrackLike, getUserFavoritesData } = useUserInformation();
   const [swiperRef, setSwiperRef] = useState<SwiperClass>();
@@ -40,7 +43,7 @@ const CompletedSearch = () => {
   const handleArtistDetailTrack = useCallback(
     // Detail Artist
     (artistData: SpotifyArtistProps) => {
-      mutateTrack(artistData.artistName);
+      mutateArtistDetailTrack(artistData.artistName);
       setGetSpotifyArtistForDetailArtist(artistData);
       setIsHidden(true);
       swiperRef?.slideNext();
@@ -54,6 +57,7 @@ const CompletedSearch = () => {
       window.history.back();
     } else {
       swiperRef?.slidePrev();
+      setSpotifyArtistDetailTrackData([]);
     }
   }, [swiperRef]);
 
@@ -91,6 +95,7 @@ const CompletedSearch = () => {
       }}
       spotifyArtistData={spotifyArtistData}
       spotifyTrackData={spotifyTrackData}
+      spotifyArtistDetailTrackData={spotifyArtistDetailTrackData}
       commaUserData={commaUserData}
       setSwiperRef={setSwiperRef}
       onClickArtistAvata={handleArtistDetailTrack}

--- a/src/pages/quest/completedSearch.tsx
+++ b/src/pages/quest/completedSearch.tsx
@@ -37,7 +37,7 @@ const CompletedSearch = () => {
     }));
   };
 
-  const handleArtistAvata = useCallback(
+  const handleArtistDetailTrack = useCallback(
     // Detail Artist
     (artistData: SpotifyArtistProps) => {
       mutateTrack(artistData.artistName);
@@ -58,11 +58,17 @@ const CompletedSearch = () => {
   }, [swiperRef]);
 
   useEffect(() => {
-    if (searchItems.category === 'music') {
+    if (searchItems.category === 'music' && spotifyTrackData === undefined) {
       mutateTrack(searchItems.searchText);
-    } else if (searchItems.category === 'artist') {
+    } else if (
+      searchItems.category === 'artist' &&
+      spotifyArtistData === undefined
+    ) {
       mutateArtist(searchItems.searchText);
-    } else if (searchItems.category === 'commaUser') {
+    } else if (
+      searchItems.category === 'commaUser' &&
+      commaUserData === undefined
+    ) {
       mutateCommaUser(searchItems.searchText);
     }
   }, [searchItems.searchText, searchItems.category]);
@@ -87,7 +93,7 @@ const CompletedSearch = () => {
       spotifyTrackData={spotifyTrackData}
       commaUserData={commaUserData}
       setSwiperRef={setSwiperRef}
-      onClickArtistAvata={handleArtistAvata}
+      onClickArtistAvata={handleArtistDetailTrack}
       spotifyArtistForDetailArtist={getSpotifyArtistForDetailArtist}
       isHidden={isHidden}
     />


### PR DESCRIPTION
## Jira Issue 번호
140

## 작업 내용
ArtistDetailTrack 과 Track 이 같은 hook을 사용해서 Slide 라이브러리를 사용 시 Track Data가 이미 존재하여 Artist Category Slide에 여백이 생기는 버그가 있었습니다.
데이터를 분리시켰고, Artist Slide로 넘어오면 Artist Detail Track에 데이터를 삭제해서 Artist Slide에 여백이 생기는 버그를 해결했습니다.

추가로 Artist, Track, CommaUser 에 데이터가 있다면 그 이후로는 api 호출하지 않도록 수정했습니다.

## Checklist

- [x] PR 제목이 convention 에 맞는지 체크
- [x] PR Label 설정
- [x] Code Review 요청
- [x] Jira 리뷰 요청 상태로 변경
